### PR TITLE
Fixing some bugs to improve robustness

### DIFF
--- a/aiosseclient.py
+++ b/aiosseclient.py
@@ -130,6 +130,8 @@ async def aiosseclient(
                 line = line.decode('utf8')
 
                 if line in {'\n', '\r', '\r\n'}:
+                    if not lines:
+                        continue
                     if lines[0] == ':ok\n':
                         lines = []
                         continue

--- a/aiosseclient.py
+++ b/aiosseclient.py
@@ -87,7 +87,7 @@ class Event:
             elif name == 'id':
                 msg.id = value
             elif name == 'retry':
-                msg.retry = int(value)
+                msg.retry = bool(value)
 
         return msg
 
@@ -102,9 +102,11 @@ async def aiosseclient(
     valid_http_codes: List[int] = [200, 301, 307],
     exit_events: List[str] = [],
     timeout_total: Optional[float] = None,
-    headers: Optional[dict[str, str]] = {},
+    headers: Optional[dict[str, str]] = None,
 ) -> AsyncGenerator[Event, None]:
     '''Canonical API of the library'''
+    if headers is None:
+        headers = dict()
     # The SSE spec requires making requests with Cache-Control: nocache
     headers['Cache-Control'] = 'no-cache'
 

--- a/aiosseclient.py
+++ b/aiosseclient.py
@@ -118,6 +118,7 @@ async def aiosseclient(
     timeout = aiohttp.ClientTimeout(total=timeout_total, connect=None,
                                     sock_connect=None, sock_read=None)
     async with aiohttp.ClientSession(timeout=timeout) as session:
+        response = None
         try:
             _LOGGER.info('Session created: %s', session)
             response = await session.get(url, headers=headers)
@@ -143,5 +144,7 @@ async def aiosseclient(
         except TimeoutError as sseerr:
             _LOGGER.error('TimeoutError: %s', sseerr)
         finally:
+            if response:
+                response.close()
             if not session.closed:
                 await session.close()


### PR DESCRIPTION
1. The python SSE client can handle atypical SSE messages if there are more than one empty lines after each message received.
2. Close response when the connection ends so that there is no `aiohttp` error.
3. Change `msg.retry` to receive `bool(value)` to suppress Pylance typing errors in VS Code, etc.