### PR TITLE
Avoid overwriting the accept header

### DIFF
--- a/aiosseclient.py
+++ b/aiosseclient.py
@@ -111,8 +111,9 @@ async def aiosseclient(
     # The SSE spec requires making requests with Cache-Control: nocache
     headers['Cache-Control'] = 'no-cache'
 
-    # The 'Accept' header is not required, but explicit > implicit
-    headers['Accept'] = 'text/event-stream'
+    if 'Accept' not in headers:
+        # The 'Accept' header is not required, but explicit > implicit
+        headers['Accept'] = 'text/event-stream'
 
     if last_id:
         headers['Last-Event-ID'] = last_id


### PR DESCRIPTION
So I have the use case that I need to do an SSE request with a different Accept header than just `text/event-stream`. But, the library overwrites this, and that doesn't work for my use case, so ideally we only set the explicit `Accept` header if its not present yet.

I would appreciate a release after this